### PR TITLE
fix the path_to_current_controller_form helper method to use the righ…

### DIFF
--- a/lib/modal_logic/helpers.rb
+++ b/lib/modal_logic/helpers.rb
@@ -28,7 +28,7 @@ module ModalLogic
     end
 
     def path_to_current_controller_form( opts = {} )
-      File.join(Rails.root, 'app/views', params[:controller], opts[:filename] || '_form')
+      File.join(params[:controller], opts[:filename] || '_form')
     end
   end
 end


### PR DESCRIPTION
…t path for partials, as the old path no longer works for Rails 4.1 and above. 
